### PR TITLE
Student5 m08 & m09

### DIFF
--- a/src/main/java/acme/features/technician/involves/TechnicianInvolvesCreateService.java
+++ b/src/main/java/acme/features/technician/involves/TechnicianInvolvesCreateService.java
@@ -35,6 +35,30 @@ public class TechnicianInvolvesCreateService extends AbstractGuiService<Technici
 		maintenanceRecord = this.repository.findMaintenanceRecordById(id);
 		status = super.getRequest().getPrincipal().hasRealm(maintenanceRecord.getTechnician());
 
+		if (status) {
+			String method;
+			Collection<Task> possibleTasks;
+			Collection<Task> alreadyAddedTasks;
+			int taskId;
+			Task task;
+
+			method = super.getRequest().getMethod();
+
+			if (method.equals("GET"))
+				status = true;
+			else {
+				taskId = super.getRequest().getData("task", int.class);
+				if (taskId != 0) {
+					task = this.repository.findTaskById(taskId);
+					possibleTasks = this.repository.findTasksPublished();
+					alreadyAddedTasks = this.repository.findInvolvesByMaintenanceRecordId(maintenanceRecord.getId()).stream().map(Involves::getTask).toList();
+					possibleTasks.removeAll(alreadyAddedTasks);
+					status = possibleTasks.contains(task);
+				}
+
+			}
+		}
+
 		super.getResponse().setAuthorised(status);
 	}
 

--- a/src/main/java/acme/features/technician/involves/TechnicianInvolvesRepository.java
+++ b/src/main/java/acme/features/technician/involves/TechnicianInvolvesRepository.java
@@ -29,4 +29,7 @@ public interface TechnicianInvolvesRepository extends AbstractRepository {
 	@Query("select i from Involves i where i.id = :id")
 	Involves findInvolvesById(int id);
 
+	@Query("select t from Task t where t.id = :id")
+	Task findTaskById(int id);
+
 }

--- a/src/main/java/acme/features/technician/maintenanceRecord/TechnicianMaintenanceRecordCreateService.java
+++ b/src/main/java/acme/features/technician/maintenanceRecord/TechnicianMaintenanceRecordCreateService.java
@@ -58,8 +58,9 @@ public class TechnicianMaintenanceRecordCreateService extends AbstractGuiService
 		aircraftId = super.getRequest().getData("aircraft", int.class);
 		aircraft = this.repository.findAircraftById(aircraftId);
 
-		super.bindObject(maintenanceRecord, "status", "inspectionDueDate", "estimatedCost", "notes");
+		super.bindObject(maintenanceRecord, "inspectionDueDate", "estimatedCost", "notes");
 		maintenanceRecord.setAircraft(aircraft);
+		maintenanceRecord.setStatus(MaintenanceStatus.PENDING);
 	}
 
 	@Override
@@ -76,12 +77,6 @@ public class TechnicianMaintenanceRecordCreateService extends AbstractGuiService
 				super.state(inspectionDueDateIsAfterMaintenanceMoment, "inspectionDueDate", "acme.validation.maintenance-record.inspectionDueDate-is-after-maintenanceMoment");
 			}
 		}
-		{
-			if (maintenanceRecord.getStatus() != null) {
-				boolean maintenanceRecordIsNotCompletedYet = !maintenanceRecord.getStatus().equals(MaintenanceStatus.COMPLETED);
-				super.state(maintenanceRecordIsNotCompletedYet, "status", "acme.validation.maintenance-record.maintenance-record-is-not-completed-yet");
-			}
-		}
 	}
 
 	@Override
@@ -92,16 +87,13 @@ public class TechnicianMaintenanceRecordCreateService extends AbstractGuiService
 	@Override
 	public void unbind(final MaintenanceRecord maintenanceRecord) {
 		Dataset dataset;
-		SelectChoices statusChoices;
 		Collection<Aircraft> aircrafts;
 		SelectChoices aircraftChoices;
 
-		statusChoices = SelectChoices.from(MaintenanceStatus.class, maintenanceRecord.getStatus());
 		aircrafts = this.repository.findAllAircrafts();
 		aircraftChoices = SelectChoices.from(aircrafts, "registrationNumber", maintenanceRecord.getAircraft());
 
-		dataset = super.unbindObject(maintenanceRecord, "maintenanceMoment", "status", "inspectionDueDate", "estimatedCost", "notes", "draftMode");
-		dataset.put("statuses", statusChoices);
+		dataset = super.unbindObject(maintenanceRecord, "maintenanceMoment", "inspectionDueDate", "estimatedCost", "notes", "draftMode");
 		dataset.put("aircraft", aircraftChoices.getSelected().getKey());
 		dataset.put("aircrafts", aircraftChoices);
 

--- a/src/main/java/acme/features/technician/maintenanceRecord/TechnicianMaintenanceRecordCreateService.java
+++ b/src/main/java/acme/features/technician/maintenanceRecord/TechnicianMaintenanceRecordCreateService.java
@@ -30,7 +30,23 @@ public class TechnicianMaintenanceRecordCreateService extends AbstractGuiService
 
 	@Override
 	public void authorise() {
-		super.getResponse().setAuthorised(true);
+		boolean status;
+
+		String method;
+		int aircraftId;
+		Aircraft aircraft;
+
+		method = super.getRequest().getMethod();
+
+		if (method.equals("GET"))
+			status = true;
+		else {
+			aircraftId = super.getRequest().getData("aircraft", int.class);
+			aircraft = this.repository.findAircraftById(aircraftId);
+			status = aircraft != null || aircraftId == 0;
+		}
+
+		super.getResponse().setAuthorised(status);
 	}
 
 	@Override

--- a/src/main/java/acme/features/technician/maintenanceRecord/TechnicianMaintenanceRecordPublishService.java
+++ b/src/main/java/acme/features/technician/maintenanceRecord/TechnicianMaintenanceRecordPublishService.java
@@ -38,6 +38,22 @@ public class TechnicianMaintenanceRecordPublishService extends AbstractGuiServic
 		technician = maintenanceRecord == null ? null : maintenanceRecord.getTechnician();
 		status = maintenanceRecord != null && maintenanceRecord.isDraftMode() && super.getRequest().getPrincipal().hasRealm(technician);
 
+		if (status) {
+			String method;
+			int aircraftId;
+			Aircraft aircraft;
+
+			method = super.getRequest().getMethod();
+
+			if (method.equals("GET"))
+				status = true;
+			else {
+				aircraftId = super.getRequest().getData("aircraft", int.class);
+				aircraft = this.repository.findAircraftById(aircraftId);
+				status = aircraft != null || aircraftId == 0;
+			}
+		}
+
 		super.getResponse().setAuthorised(status);
 
 	}

--- a/src/main/java/acme/features/technician/maintenanceRecord/TechnicianMaintenanceRecordPublishService.java
+++ b/src/main/java/acme/features/technician/maintenanceRecord/TechnicianMaintenanceRecordPublishService.java
@@ -71,7 +71,7 @@ public class TechnicianMaintenanceRecordPublishService extends AbstractGuiServic
 
 	@Override
 	public void bind(final MaintenanceRecord maintenanceRecord) {
-		super.bindObject(maintenanceRecord, "status", "inspectionDueDate", "estimatedCost", "notes");
+		super.bindObject(maintenanceRecord, "status", "inspectionDueDate", "estimatedCost", "notes", "aircraft");
 	}
 
 	@Override

--- a/src/main/java/acme/features/technician/maintenanceRecord/TechnicianMaintenanceRecordUpdateService.java
+++ b/src/main/java/acme/features/technician/maintenanceRecord/TechnicianMaintenanceRecordUpdateService.java
@@ -39,6 +39,22 @@ public class TechnicianMaintenanceRecordUpdateService extends AbstractGuiService
 		technician = maintenanceRecord == null ? null : maintenanceRecord.getTechnician();
 		status = maintenanceRecord != null && maintenanceRecord.isDraftMode() && super.getRequest().getPrincipal().hasRealm(technician);
 
+		if (status) {
+			String method;
+			int aircraftId;
+			Aircraft aircraft;
+
+			method = super.getRequest().getMethod();
+
+			if (method.equals("GET"))
+				status = true;
+			else {
+				aircraftId = super.getRequest().getData("aircraft", int.class);
+				aircraft = this.repository.findAircraftById(aircraftId);
+				status = aircraft != null || aircraftId == 0;
+			}
+		}
+
 		super.getResponse().setAuthorised(status);
 	}
 

--- a/src/main/java/acme/features/technician/task/TechnicianTaskListService.java
+++ b/src/main/java/acme/features/technician/task/TechnicianTaskListService.java
@@ -42,7 +42,7 @@ public class TechnicianTaskListService extends AbstractGuiService<Technician, Ta
 	public void unbind(final Task task) {
 		Dataset dataset;
 
-		dataset = super.unbindObject(task, "type", "priority", "estimatedDuration", "description");
+		dataset = super.unbindObject(task, "type", "priority", "estimatedDuration", "description", "draftMode");
 
 		super.getResponse().addData(dataset);
 	}

--- a/src/main/resources/WEB-INF/views/technician/maintenance-record/form.jsp
+++ b/src/main/resources/WEB-INF/views/technician/maintenance-record/form.jsp
@@ -20,10 +20,10 @@
 	<jstl:if test="${_command != 'create'}">
 	
 		<acme:input-moment code="technician.maintenance-record.list.label.maintenanceMoment" path="maintenanceMoment" readonly="true"/>
+		<acme:input-select code="technician.maintenance-record.form.label.status" path="status" choices="${statuses}"/>
 	
 	</jstl:if>
 
-	<acme:input-select code="technician.maintenance-record.form.label.status" path="status" choices="${statuses}"/>
 	<acme:input-moment code="technician.maintenance-record.form.label.inspectionDueDate" path="inspectionDueDate"/>
 	<acme:input-money code="technician.maintenance-record.form.label.estimatedCost" path="estimatedCost"/>
 	<acme:input-textarea code="technician.maintenance-record.form.label.notes" path="notes"/>

--- a/src/main/resources/WEB-INF/views/technician/task/list.jsp
+++ b/src/main/resources/WEB-INF/views/technician/task/list.jsp
@@ -21,6 +21,10 @@
 	<acme:list-column code="technician.task.list.label.priority" path="priority" width="10%"/>
 	<acme:list-column code="technician.task.list.label.estimatedDuration" path="estimatedDuration" width="10%"/>
 	
+	<jstl:if test="${_command == 'list'}">
+		<acme:list-column code="technician.task.list.label.draftMode" path="draftMode" width="10%"/>
+	</jstl:if>
+	
 	<jstl:if test="${_command == 'listAllPublished'}">
 		<acme:list-column code="technician.task.list.label.technician" path="technician" width="10%"/>
 	</jstl:if>

--- a/src/main/resources/WEB-INF/views/technician/task/messages-en.i18n
+++ b/src/main/resources/WEB-INF/views/technician/task/messages-en.i18n
@@ -16,6 +16,7 @@ technician.task.form.label.description = Description
 technician.task.form.label.priority = Priority
 technician.task.form.label.estimatedDuration = Estimated duration
 technician.task.form.label.technician = Technician
+technician.task.list.label.draftMode = Draft mode
 
 technician.task.form.placeholder.estimatedDuration = 0 - 6000
 technician.task.form.placeholder.priority = 0 - 10

--- a/src/main/resources/WEB-INF/views/technician/task/messages-es.i18n
+++ b/src/main/resources/WEB-INF/views/technician/task/messages-es.i18n
@@ -16,6 +16,7 @@ technician.task.form.label.description = Descripción
 technician.task.form.label.priority = Prioridad
 technician.task.form.label.estimatedDuration = Duración estimada
 technician.task.form.label.technician = Técnico
+technician.task.list.label.draftMode = Modo borrador
 
 technician.task.form.placeholder.estimatedDuration = 0 - 6000
 technician.task.form.placeholder.priority = 0 - 10


### PR DESCRIPTION
## Resumen de los cambios

Se han añadido prevenciones al authorise para Post-Hacking, en concreto para:

#### MaintenanceRecord
- `CreateService`: No se puede poner un id inválido en el campo "aircraft", pero sí se puede poner el id = 0 para que salte la restricción de null
- `UpdateService`: No se puede poner un id inválido en el campo "aircraft", pero sí se puede poner el id = 0 para que salte la restricción de null
- `PublishService`: No se puede poner un id inválido en el campo "aircraft", pero sí se puede poner el id = 0 para que salte la restricción de null

#### Involves
- `CreateService`: No se puede poner una task inválida (las que no están habilitadas para seleccionar), teniendo en cuenta que dejar el campo vacío sólo hace saltar la restricción de null